### PR TITLE
Group same functions together

### DIFF
--- a/lib/xslt.ex
+++ b/lib/xslt.ex
@@ -30,15 +30,15 @@ defmodule Xslt do
     Porcelain.shell("xsltproc #{template} #{xml}")
     |> handle_output
   end
+  def transform(_, xml) when is_bitstring(xml), do: File.read(xml)
+  def transform(_, _), do: {:error, :bad_arguments}
+ 
   def transform(template, xml, params)  when is_bitstring(template) and is_bitstring(xml) and is_bitstring(params) do
     Porcelain.shell("xsltproc #{params} #{template} #{xml}")
     |> handle_output
   end
-  def transform(_, xml) when is_bitstring(xml), do: File.read(xml)
   def transform(template, xml, _) when is_bitstring(template) and is_bitstring(xml), do: transform(template, xml)
   def transform(_, xml, _) when is_bitstring(xml), do: File.read(xml)
-
-  def transform(_, _), do: {:error, :bad_arguments}
   def transform(_, _, _), do: {:error, :bad_arguments}
 
   @spec handle_output(result :: Result.t) :: result


### PR DESCRIPTION
This change solves the only warnings generated by this library during building:

```
==> xslt
Compiling 1 file (.ex)
warning: clauses for the same def should be grouped together, def transform/2 was previously defined (lib/xslt.ex:29)
  lib/xslt.ex:37

warning: clauses for the same def should be grouped together, def transform/3 was previously defined (lib/xslt.ex:33)
  lib/xslt.ex:38

warning: clauses for the same def should be grouped together, def transform/2 was previously defined (lib/xslt.ex:37)
  lib/xslt.ex:41

warning: clauses for the same def should be grouped together, def transform/3 was previously defined (lib/xslt.ex:39)
  lib/xslt.ex:42
```