### PR TITLE
Added single quotes to file paths

### DIFF
--- a/lib/xslt.ex
+++ b/lib/xslt.ex
@@ -27,14 +27,14 @@ defmodule Xslt do
   """
 
   def transform(template, xml) when is_bitstring(template) and is_bitstring(xml) do
-    Porcelain.shell("xsltproc #{template} #{xml}")
+    Porcelain.shell("xsltproc '#{template}' '#{xml}'")
     |> handle_output
   end
   def transform(_, xml) when is_bitstring(xml), do: File.read(xml)
   def transform(_, _), do: {:error, :bad_arguments}
- 
+
   def transform(template, xml, params)  when is_bitstring(template) and is_bitstring(xml) and is_bitstring(params) do
-    Porcelain.shell("xsltproc #{params} #{template} #{xml}")
+    Porcelain.shell("xsltproc #{params} '#{template}' '#{xml}'")
     |> handle_output
   end
   def transform(template, xml, _) when is_bitstring(template) and is_bitstring(xml), do: transform(template, xml)


### PR DESCRIPTION
Added single quotes to file paths in `xsltproc` calls to support paths with spaces.

I have my development files in an external HD, which is linked to `~/Developer`, but it is physically mounted at `/Volumes/External HD/Developer...`. Running `xsltproc` with a template and a file with this path resulted in a path to `/Volumes/External`. Just added quotes to the given arguments to support these paths.

